### PR TITLE
chore: add new get_hyperedges_connections function

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -187,7 +187,40 @@ where
             .collect::<Vec<usize>>()
     }
 
-    /// Render the hypergraph to Graphviz dot format.
+    /// Gets the list of all hyperedges containing a matching connection from
+    /// one vertex to another.
+    pub fn get_hyperedges_connections(
+        &self,
+        from: VertexIndex,
+        to: VertexIndex,
+    ) -> Vec<HyperedgeIndex> {
+        self.vertices
+            .get_index(from)
+            .iter()
+            .fold(Vec::new(), |acc, (_, hyperedges)| {
+                hyperedges
+                    .iter()
+                    .enumerate()
+                    .fold(acc, |hyperedge_acc, (index, hyperedge)| {
+                        hyperedge.iter().tuple_windows::<(_, _)>().fold(
+                            hyperedge_acc,
+                            |index_acc, (window_from, window_to)| {
+                                // Inject the index of the hyperedge if the current window is a match.
+                                if *window_from == from && *window_to == to {
+                                    return index_acc
+                                        .into_iter()
+                                        .chain(vec![index])
+                                        .collect::<Vec<usize>>();
+                                }
+
+                                index_acc
+                            },
+                        )
+                    })
+            })
+    }
+
+    /// Renders the hypergraph to Graphviz dot format.
     /// Due to Graphviz dot inability to render hypergraphs out of the box,
     /// unaries are rendered as vertex peripheries which can't be labelled.
     pub fn render_to_graphviz_dot(&self) {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -31,6 +31,7 @@ fn integration() {
 
     // Add some hyperedges.
     assert_eq!(graph.add_hyperedge(&[0, 1, 1, 3], "foo"), (0, 0)); // self-loop.
+    assert_eq!(graph.add_hyperedge(&[0, 1, 1, 3], "foo_"), (0, 1));
     assert_eq!(graph.add_hyperedge(&[4, 0, 3, 2], "bar"), (1, 0));
     assert_eq!(graph.add_hyperedge(&[3], "woot"), (2, 0)); // unary.
     assert_eq!(graph.add_hyperedge(&[3], "woot"), (2, 0)); // adding the exact same hyperedge results in an update.
@@ -38,7 +39,7 @@ fn integration() {
 
     // Count the vertices and the hyperedges.
     assert_eq!(graph.count_vertices(), 5);
-    assert_eq!(graph.count_hyperedges(), 4);
+    assert_eq!(graph.count_hyperedges(), 5);
 
     // Get the weights of some hyperedges and vertices.
     assert_eq!(graph.get_vertex_weight(0), Some(&a));
@@ -53,22 +54,18 @@ fn integration() {
     assert_eq!(graph.get_hyperedge_vertices(3), None); // should not fail!
 
     // Check hyperedges intersections.
-    assert_eq!(
-        graph.get_hyperedges_intersections(&[0, 1]),
-        vec![0 as usize, 3 as usize]
-    );
-    assert_eq!(
-        graph.get_hyperedges_intersections(&[0, 1, 2]),
-        vec![3 as usize]
-    );
-    assert_eq!(
-        graph.get_hyperedges_intersections(&[0]),
-        vec![0 as usize, 1 as usize, 3 as usize]
-    );
+    assert_eq!(graph.get_hyperedges_intersections(&[0, 1]), vec![0, 3]);
+    assert_eq!(graph.get_hyperedges_intersections(&[0, 1, 2]), vec![3]);
+    assert_eq!(graph.get_hyperedges_intersections(&[0]), vec![0, 1, 3]);
     assert_eq!(
         graph.get_hyperedges_intersections(&[3]), // should not fail!
         vec![]
     );
+
+    // Get the hyperedges connecting some vertices.
+    assert_eq!(graph.get_hyperedges_connections(1, 1), vec![0]);
+    assert_eq!(graph.get_hyperedges_connections(3, 2), vec![1]);
+    assert_eq!(graph.get_hyperedges_connections(3, 0), vec![]); // no match, should stay empty!
 
     graph.render_to_graphviz_dot();
 }


### PR DESCRIPTION
This PR implements a new function to get a list of hyperedges connecting two given vertices.