### PR TITLE
Feat/into iter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ rust-version = "1.56"
 version = "1.0.8-alpha.0"
 
 [dependencies]
-indexmap = "1.7.0"
+indexmap = "1.8.0"
 itertools = "0.10.3"
 thiserror = "1.0.30"

--- a/src/core/hyperedges/get_hyperedge_weight.rs
+++ b/src/core/hyperedges/get_hyperedge_weight.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use crate::{errors::HypergraphError, HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexTrait};
 
 impl<V, HE> Hypergraph<V, HE>
@@ -9,7 +11,7 @@ where
     pub fn get_hyperedge_weight(
         &self,
         hyperedge_index: HyperedgeIndex,
-    ) -> Result<HE, HypergraphError<V, HE>> {
+    ) -> Result<&HE, HypergraphError<V, HE>> {
         let internal_index = self.get_internal_hyperedge(hyperedge_index)?;
 
         let hyperedge_key = self
@@ -17,6 +19,6 @@ where
             .get_index(internal_index)
             .ok_or(HypergraphError::InternalVertexIndexNotFound(internal_index))?;
 
-        Ok(hyperedge_key.weight)
+        Ok(hyperedge_key.deref())
     }
 }

--- a/src/core/indexes.rs
+++ b/src/core/indexes.rs
@@ -1,0 +1,37 @@
+use std::fmt::{Display, Formatter, Result};
+
+/// Vertex stable index representation as usize.
+/// Uses the newtype index pattern.
+/// <https://matklad.github.io/2018/06/04/newtype-index-pattern.html>
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct VertexIndex(pub usize);
+
+impl Display for VertexIndex {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl From<usize> for VertexIndex {
+    fn from(index: usize) -> Self {
+        VertexIndex(index)
+    }
+}
+
+/// Hyperedge stable index representation as usize.
+/// Uses the newtype index pattern.
+/// <https://matklad.github.io/2018/06/04/newtype-index-pattern.html>
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct HyperedgeIndex(pub usize);
+
+impl Display for HyperedgeIndex {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<usize> for HyperedgeIndex {
+    fn from(index: usize) -> Self {
+        HyperedgeIndex(index)
+    }
+}

--- a/src/core/iterator.rs
+++ b/src/core/iterator.rs
@@ -1,0 +1,70 @@
+use itertools::Itertools;
+
+use crate::{errors::HypergraphError, HyperedgeKey, HyperedgeTrait, Hypergraph, VertexTrait};
+
+impl<V, HE> IntoIterator for Hypergraph<V, HE>
+where
+    V: VertexTrait,
+    HE: HyperedgeTrait,
+{
+    type Item = (HE, Vec<V>);
+    type IntoIter = HypergraphIterator<V, HE>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        HypergraphIterator {
+            hypergraph: self,
+            index: 0,
+        }
+    }
+}
+
+/// Ideally we should be able to use GATs to expose `iter()`:
+/// <https://rust-lang.github.io/generic-associated-types-initiative/explainer.html>
+#[derive(Debug)]
+pub struct HypergraphIterator<V, HE>
+where
+    V: VertexTrait,
+    HE: HyperedgeTrait,
+{
+    hypergraph: Hypergraph<V, HE>,
+    index: usize,
+}
+
+impl<V, HE> Iterator for HypergraphIterator<V, HE>
+where
+    V: VertexTrait,
+    HE: HyperedgeTrait,
+{
+    type Item = (HE, Vec<V>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Get the current hyperedge matching the index.
+        match self.hypergraph.hyperedges.iter().nth(self.index) {
+            // Extract the internal vertices and its weight.
+            Some(HyperedgeKey { vertices, weight }) => {
+                // Convert the internal vertices to a vector of VertexIndex.
+                // Since this is a fallible operation and we can't deal with a
+                // Result within this iterator, remap to None on error.
+                match self.hypergraph.get_vertices(vertices.to_owned()) {
+                    Ok(indexes) => {
+                        match indexes
+                            .iter()
+                            .map(|index| self.hypergraph.get_vertex_weight(*index))
+                            .collect::<Result<Vec<&V>, HypergraphError<V, HE>>>()
+                        {
+                            Ok(vertices_weights) => {
+                                // Now we can increment the inner index.
+                                self.index += 1;
+
+                                Some((*weight, vertices_weights.into_iter().cloned().collect_vec()))
+                            }
+                            Err(_) => None,
+                        }
+                    }
+                    Err(_) => None,
+                }
+            }
+            None => None,
+        }
+    }
+}

--- a/src/core/vertices/get_dijkstra_connections.rs
+++ b/src/core/vertices/get_dijkstra_connections.rs
@@ -121,7 +121,7 @@ where
 
                     // Use the trait implementation to get the associated cost
                     // of the hyperedge.
-                    let cost = hyperedge_weight.into();
+                    let cost = hyperedge_weight.to_owned().into();
 
                     if cost < min_cost {
                         min_cost = cost;

--- a/src/core/vertices/get_vertex_weight.rs
+++ b/src/core/vertices/get_vertex_weight.rs
@@ -9,12 +9,12 @@ where
     pub fn get_vertex_weight(
         &self,
         vertex_index: VertexIndex,
-    ) -> Result<V, HypergraphError<V, HE>> {
+    ) -> Result<&V, HypergraphError<V, HE>> {
         let internal_index = self.get_internal_vertex(vertex_index)?;
 
         self.vertices
             .get_index(internal_index)
-            .map(|(weight, _)| *weight)
+            .map(|(weight, _)| weight)
             .ok_or(HypergraphError::InternalVertexIndexNotFound(internal_index))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,84 +29,100 @@
 //! use hypergraph::{HyperedgeIndex, Hypergraph, VertexIndex};
 //! use std::fmt::{Display, Formatter, Result};
 //!
-//! // Create a new struct to represent a vertex.
+//! // Create a new struct to represent a person.
 //! #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
-//! pub struct Vertex<'a> {
+//! pub struct Person<'a> {
 //!     name: &'a str,
 //! }
 //!
-//! impl<'a> Vertex<'a> {
+//! impl<'a> Person<'a> {
 //!     pub fn new(name: &'a str) -> Self {
-//!         Vertex { name }
+//!         Self { name }
 //!     }
 //! }
 //!
-//! impl<'a> Display for Vertex<'a> {
+//! impl<'a> Display for Person<'a> {
 //!     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
 //!         write!(f, "{}", self)
 //!     }
 //! }
 //!
-//! // Create a new struct to represent a hyperedge.
+//! // Create a new struct to represent a relation.
 //! #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
-//! pub struct Hyperedge<'a> {
+//! pub struct Relation<'a> {
 //!     cost: usize,
 //!     name: &'a str,
 //! }
 //!
-//! impl<'a> Hyperedge<'a> {
+//! impl<'a> Relation<'a> {
 //!     pub fn new(name: &'a str, cost: usize) -> Self {
-//!         Hyperedge { cost, name }
+//!         Self { cost, name }
 //!     }
 //! }
 //!
-//! impl<'a> Display for Hyperedge<'a> {
+//! impl<'a> Display for Relation<'a> {
 //!     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
 //!         write!(f, "{}", self)
 //!     }
 //! }
 //!
-//! impl<'a> Into<usize> for Hyperedge<'a> {
+//! impl<'a> Into<usize> for Relation<'a> {
 //!     fn into(self) -> usize {
 //!         self.cost
 //!     }
 //! }
 //!
 //! fn main() -> std::result::Result<(),  Box<dyn std::error::Error>> {
-//!     let mut graph = Hypergraph::<Vertex, Hyperedge>::new();
+//!     let mut graph = Hypergraph::<Person, Relation>::new();
 //!
-//!     // Add some vertices to the graph.
-//!     let ava = graph.add_vertex(Vertex::new("Ava"))?;
-//!     let bianca = graph.add_vertex(Vertex::new("Bianca"))?;
-//!     let charles = graph.add_vertex(Vertex::new("Charles"))?;
-//!     let daena = graph.add_vertex(Vertex::new("Daena"))?;
-//!     let ewan = graph.add_vertex(Vertex::new("Ewan"))?;
-//!     let faarooq = graph.add_vertex(Vertex::new("Faarooq"))?;
-//!     let ghanda = graph.add_vertex(Vertex::new("Ghanda"))?;
+//!     // Create some folks.
+//!     let ava_person = Person::new("Ava");
+//!     let bianca_person = Person::new("Bianca");
+//!     let charles_person = Person::new("Charles");
+//!     let daena_person = Person::new("Daena");
+//!     let ewan_person = Person::new("Ewan");
+//!     let faarooq_person = Person::new("Faarooq");
+//!     let ghanda_person = Person::new("Ghanda");
+//!
+//!     // Add those to the graph as vertices.
+//!     let ava = graph.add_vertex(ava_person)?;
+//!     let bianca = graph.add_vertex(bianca_person)?;
+//!     let charles = graph.add_vertex(charles_person)?;
+//!     let daena = graph.add_vertex(daena_person)?;
+//!     let ewan = graph.add_vertex(ewan_person)?;
+//!     let faarooq = graph.add_vertex(faarooq_person)?;
+//!     let ghanda = graph.add_vertex(ghanda_person)?;
 //!  
 //!     // Each vertex gets a unique index by insertion order.
 //!     assert_eq!(ava, VertexIndex(0));
 //!     assert_eq!(ghanda, VertexIndex(6));
 //!
 //!     // Get the weight of a vertex.
-//!     assert_eq!(graph.get_vertex_weight(VertexIndex(0)), Ok(Vertex::new("Ava")));
+//!     assert_eq!(graph.get_vertex_weight(VertexIndex(0)), Ok(&ava_person));
 //!     
-//!     // The hypergraph has 7 vertices.
+//!     // The hypergraph has seven vertices.
 //!     assert_eq!(graph.count_vertices(), 7);
 //!
-//!     // Add some hyperedges to the graph.
-//!     let first_hyperedge = graph.add_hyperedge(vec![faarooq, ava, ghanda], Hyperedge::new("share a viral video with a cat", 1))?;
-//!     let second_hyperedge = graph.add_hyperedge(vec![faarooq, ava, ghanda], Hyperedge::new("share a viral video with a dog", 1))?;
-//!     let third_hyperedge = graph.add_hyperedge(vec![ewan, ava, bianca], Hyperedge::new("share a viral video with a beaver", 1))?;
-//!     let fourth_hyperedge = graph.add_hyperedge(vec![daena], Hyperedge::new("play online", 1))?;
-//!     let fifth_hyperedge = graph.add_hyperedge(vec![ewan, charles, bianca, bianca, ewan], Hyperedge::new("pass the ball", 1))?;
+//!     // Create some relations.
+//!     let cat_video = Relation::new("share a viral video with a cat", 1);
+//!     let dog_video = Relation::new("share a viral video with a dog", 1);
+//!     let beaver_video = Relation::new("share a viral video with a beaver", 1);
+//!     let playing_online = Relation::new("play online", 1);
+//!     let passing_ball = Relation::new("pass the ball", 1);
+//!
+//!     // Add those to the graph as hyperedges.
+//!     let first_relation = graph.add_hyperedge(vec![faarooq, ava, ghanda], cat_video)?;
+//!     let second_relation = graph.add_hyperedge(vec![faarooq, ava, ghanda], dog_video)?;
+//!     let third_relation = graph.add_hyperedge(vec![ewan, ava, bianca], beaver_video)?;
+//!     let fourth_relation = graph.add_hyperedge(vec![daena], playing_online)?;
+//!     let fifth_relation = graph.add_hyperedge(vec![ewan, charles, bianca, bianca, ewan], passing_ball)?;
 //!
 //!     // Each hyperedge gets a unique index by insertion order.
-//!     assert_eq!(first_hyperedge, HyperedgeIndex(0));
-//!     assert_eq!(fifth_hyperedge, HyperedgeIndex(4));
+//!     assert_eq!(first_relation, HyperedgeIndex(0));
+//!     assert_eq!(fifth_relation, HyperedgeIndex(4));
 //!
 //!     // Get the weight of a hyperedge.
-//!     assert_eq!(graph.get_hyperedge_weight(HyperedgeIndex(0)), Ok(Hyperedge::new("share a viral video with a cat", 1)));
+//!     assert_eq!(graph.get_hyperedge_weight(HyperedgeIndex(0)), Ok(&cat_video));
 //!
 //!     // Get the vertices of a hyperedge.
 //!     assert_eq!(graph.get_hyperedge_vertices(HyperedgeIndex(0)), Ok(vec![faarooq, ava, ghanda]));
@@ -114,15 +130,15 @@
 //!     // The hypergraph has 5 hyperedges.
 //!     assert_eq!(graph.count_hyperedges(), 5);
 //!
-//!     // Get the hypergedges of a vertex.
-//!     assert_eq!(graph.get_vertex_hyperedges(VertexIndex(0)), Ok(vec![first_hyperedge, second_hyperedge, third_hyperedge]));
+//!     // Get the hyperedges of a vertex.
+//!     assert_eq!(graph.get_vertex_hyperedges(VertexIndex(0)), Ok(vec![first_relation, second_relation, third_relation]));
 //!     assert_eq!(graph.get_full_vertex_hyperedges(VertexIndex(0)), Ok(vec![vec![faarooq, ava, ghanda], vec![faarooq, ava, ghanda], vec![ewan, ava, bianca]]));
 //!     
 //!     // Get the intersection of some hyperedges.
-//!     assert_eq!(graph.get_hyperedges_intersections(vec![second_hyperedge, third_hyperedge]), Ok(vec![ava]));
+//!     assert_eq!(graph.get_hyperedges_intersections(vec![second_relation, third_relation]), Ok(vec![ava]));
 //!
 //!     // Find a hyperedge containing a connection between two vertices.
-//!     assert_eq!(graph.get_hyperedges_connecting(bianca, bianca), Ok(vec![fifth_hyperedge]));
+//!     assert_eq!(graph.get_hyperedges_connecting(bianca, bianca), Ok(vec![fifth_relation]));
 //!
 //!     // Get the adjacent vertices from a vertex.
 //!     assert_eq!(graph.get_adjacent_vertices_from(VertexIndex(0)), Ok(vec![bianca, ghanda]));
@@ -131,25 +147,25 @@
 //!     assert_eq!(graph.get_adjacent_vertices_to(VertexIndex(0)), Ok(vec![ewan, faarooq]));
 //!
 //!     // Find the shortest paths between some vertices.
-//!     assert_eq!(graph.get_dijkstra_connections(faarooq, bianca), Ok(vec![(faarooq, None), (ava, Some(first_hyperedge)), (bianca, Some(third_hyperedge))]));
+//!     assert_eq!(graph.get_dijkstra_connections(faarooq, bianca), Ok(vec![(faarooq, None), (ava, Some(first_relation)), (bianca, Some(third_relation))]));
 //!
 //!     // Update the weight of a vertex.
-//!     graph.update_vertex_weight(ava, Vertex::new("Avā"))?;
+//!     graph.update_vertex_weight(ava, Person::new("Avā"))?;
 //!     
 //!     // Update the weight of a hyperedge.
-//!     graph.update_hyperedge_weight(third_hyperedge, Hyperedge::new("share a viral video with a capybara", 1))?;
+//!     graph.update_hyperedge_weight(third_relation, Relation::new("share a viral video with a capybara", 1))?;
 //!
 //!     // Update the vertices of a hyperedge.
-//!     graph.update_hyperedge_vertices(third_hyperedge, vec![ewan, ava, daena])?;
+//!     graph.update_hyperedge_vertices(third_relation, vec![ewan, ava, daena])?;
 //!
 //!     // Remove a hyperedge.
-//!     graph.remove_hyperedge(first_hyperedge)?;
+//!     graph.remove_hyperedge(first_relation)?;
 //!
 //!     // Remove a vertex.
 //!     graph.remove_vertex(ewan)?;
 //!
 //!     // Reverse a hyperedge.
-//!     graph.reverse_hyperedge(fifth_hyperedge)?;
+//!     graph.reverse_hyperedge(fifth_relation)?;
 //!
 //!     // Get the in-degree of a vertex.
 //!     assert_eq!(graph.get_vertex_degree_in(ava), Ok(1));
@@ -158,7 +174,7 @@
 //!     assert_eq!(graph.get_vertex_degree_out(ghanda), Ok(0));
 //!
 //!     // Contract a hyperedge's vertices.
-//!     graph.contract_hyperedge_vertices(fifth_hyperedge, vec![bianca, charles], bianca)?;
+//!     graph.contract_hyperedge_vertices(fifth_relation, vec![bianca, charles], bianca)?;
 //!
 //!     // Clear the hyperedges.
 //!     graph.clear_hyperedges()?;
@@ -170,7 +186,7 @@
 //! }
 //! ```
 
-/// Public API.
+#[doc(hidden)]
 pub mod core;
 
 // Reexport of the public API.

--- a/tests/integration_dijkstra.rs
+++ b/tests/integration_dijkstra.rs
@@ -7,7 +7,7 @@ use common::{Hyperedge, Vertex};
 use hypergraph::Hypergraph;
 
 #[test]
-fn integration() {
+fn integration_dijkstra() {
     // Create a new hypergraph.
     let mut graph = Hypergraph::<Vertex, Hyperedge>::new();
 

--- a/tests/integration_iterator.rs
+++ b/tests/integration_iterator.rs
@@ -1,0 +1,52 @@
+#![deny(unsafe_code, nonstandard_style)]
+#![forbid(rust_2021_compatibility)]
+
+mod common;
+
+use common::{Hyperedge, Vertex};
+use hypergraph::Hypergraph;
+
+#[test]
+fn integration_iterator() {
+    // Create a new hypergraph.
+    let mut graph = Hypergraph::<Vertex, Hyperedge>::new();
+
+    // Create some vertice weights.
+    let vertex_one = Vertex::new("one");
+    let vertex_two = Vertex::new("two");
+    let vertex_three = Vertex::new("three");
+    let vertex_four = Vertex::new("four");
+    let vertex_five = Vertex::new("five");
+
+    // Create some hyperedge weights.
+    let hyperedge_one = Hyperedge::new("one", 10);
+    let hyperedge_two = Hyperedge::new("two", 20);
+    let hyperedge_three = Hyperedge::new("three", 1);
+    let hyperedge_four = Hyperedge::new("four", 100);
+
+    // Create some vertices.
+    let a = graph.add_vertex(vertex_one).unwrap();
+    let b = graph.add_vertex(vertex_two).unwrap();
+    let c = graph.add_vertex(vertex_three).unwrap();
+    let d = graph.add_vertex(vertex_four).unwrap();
+    let e = graph.add_vertex(vertex_five).unwrap();
+
+    // Add some hyperedges.
+    graph.add_hyperedge(vec![a, b, c], hyperedge_one).unwrap();
+    graph.add_hyperedge(vec![d, e], hyperedge_two).unwrap();
+    graph.add_hyperedge(vec![c, c, c], hyperedge_three).unwrap();
+    graph
+        .add_hyperedge(vec![e, d, c, a], hyperedge_four)
+        .unwrap();
+
+    assert_eq!(
+        graph.into_iter().collect::<Vec<(Hyperedge, Vec<Vertex>)>>(),
+        vec![
+            (hyperedge_one, vec![vertex_one, vertex_two, vertex_three]),
+            (hyperedge_two, vec![vertex_four, vertex_five]),
+            (hyperedge_three, vec![vertex_three, vertex_three, vertex_three]),
+            (hyperedge_four, vec![vertex_five, vertex_four, vertex_three, vertex_one])
+        ],
+        "should provide `into_iter()` yelding a vector of tuples of the form (hyperedge, vector of vertices)"
+    );
+}

--- a/tests/integration_main.rs
+++ b/tests/integration_main.rs
@@ -7,7 +7,7 @@ use common::{Hyperedge, Vertex};
 use hypergraph::{errors::HypergraphError, HyperedgeIndex, Hypergraph, VertexIndex};
 
 #[test]
-fn integration() {
+fn integration_main() {
     // Create a new hypergraph.
     let mut graph = Hypergraph::<Vertex, Hyperedge>::new();
 
@@ -53,7 +53,15 @@ fn integration() {
     // Count the vertices.
     assert_eq!(graph.count_vertices(), 5, "should have 5 vertices");
 
-    // Add some hyperedges.
+    // Create some hyperedges.
+    let first_hyperedge = Hyperedge::new("pass the pink ball", 1);
+    let second_hyperedge = Hyperedge::new("pass the yellow ball", 1);
+    let third_hyperedge = Hyperedge::new("share the \"The Disordered Cosmos: A Journey into Dark Matter, Spacetime, and Dreams Deferred\" book", 2);
+    let fourth_hyperedge = Hyperedge::new("meditate like a Jedi", 10);
+    let fifth_hyperedge = Hyperedge::new("work out", 20);
+    let sixth_hyperedge = Hyperedge::new("nope", 0);
+
+    // Add those hyperedges to the hypergraph.
     assert_eq!(
         graph.add_hyperedge(
             vec![
@@ -62,7 +70,7 @@ fn integration() {
                 VertexIndex(1),
                 VertexIndex(3)
             ],
-            Hyperedge::new("pass the pink ball", 1)
+            first_hyperedge
         ),
         Ok(HyperedgeIndex(0)),
         "should add a first hyperedge which contains a self-loop on the VertexIndex 1"
@@ -75,7 +83,7 @@ fn integration() {
                 VertexIndex(1),
                 VertexIndex(3)
             ],
-            Hyperedge::new("pass the yellow ball", 1),
+            second_hyperedge,
         ),
         Ok(HyperedgeIndex(1)),
         "should add a second hyperedge which contains the same vertices as the first one"
@@ -88,41 +96,35 @@ fn integration() {
                 VertexIndex(3),
                 VertexIndex(2)
             ],
-            Hyperedge::new("share the \"The Disordered Cosmos: A Journey into Dark Matter, Spacetime, and Dreams Deferred\" book", 2)
+            third_hyperedge,
         ),
         Ok(HyperedgeIndex(2)),
         "should add a third hyperedge which is unique"
     );
     assert_eq!(
-        graph.add_hyperedge(
-            vec![VertexIndex(3)],
-            Hyperedge::new("meditate like a Jedi", 10)
-        ),
+        graph.add_hyperedge(vec![VertexIndex(3)], fourth_hyperedge,),
         Ok(HyperedgeIndex(3)),
         "should add a fourth hyperedge which contains a unary"
     );
     assert_eq!(
-        graph.add_hyperedge(
-            vec![VertexIndex(3)],
-            Hyperedge::new("meditate like a Jedi", 10)
-        ),
+        graph.add_hyperedge(vec![VertexIndex(3)], fourth_hyperedge,),
         Err(HypergraphError::HyperedgeWeightAlreadyAssigned(
-            Hyperedge::new("meditate like a Jedi", 10)
+            fourth_hyperedge
         )),
         "should return an explicit error since this weight is already in use"
     );
     assert_eq!(
-        graph.add_hyperedge(vec![VertexIndex(3)], Hyperedge::new("work out", 20)), 
-        Ok(HyperedgeIndex(4)),
-        "should add a fifth hyperedge which contains the same unary as the fourth one but with a different weight"
-    );
+            graph.add_hyperedge(vec![VertexIndex(3)], fifth_hyperedge),
+            Ok(HyperedgeIndex(4)),
+            "should add a fifth hyperedge which contains the same unary as the fourth one but with a different weight"
+        );
     assert_eq!(
-        graph.add_hyperedge(vec![VertexIndex(9)], Hyperedge::new("nope", 0)),
+        graph.add_hyperedge(vec![VertexIndex(9)], sixth_hyperedge),
         Err(HypergraphError::VertexIndexNotFound(VertexIndex(9))),
         "should be out-of-bound and return an explicit error"
     );
     assert_eq!(
-        graph.add_hyperedge(vec![], Hyperedge::new("nope", 0)),
+        graph.add_hyperedge(vec![], sixth_hyperedge),
         Err(HypergraphError::HyperedgeCreationNoVertices(
             Hyperedge::new("nope", 0)
         )),
@@ -135,12 +137,12 @@ fn integration() {
     // Get the weights of some vertices.
     assert_eq!(
         graph.get_vertex_weight(VertexIndex(0)),
-        Ok(andrea),
+        Ok(&andrea),
         "should return Andrea"
     );
     assert_eq!(
         graph.get_vertex_weight(VertexIndex(4)),
-        Ok(enola),
+        Ok(&enola),
         "should return Enola"
     );
     assert_eq!(
@@ -152,12 +154,12 @@ fn integration() {
     // Get the weights of some hyperedges.
     assert_eq!(
         graph.get_hyperedge_weight(HyperedgeIndex(0)),
-        Ok(Hyperedge::new("pass the pink ball", 1)),
+        Ok(&Hyperedge::new("pass the pink ball", 1)),
         "should get the weight of the first hyperedge"
     );
     assert_eq!(
         graph.get_hyperedge_weight(HyperedgeIndex(4)),
-        Ok(Hyperedge::new("work out", 20)),
+        Ok(&Hyperedge::new("work out", 20)),
         "should get the weight of the fifth hyperedge"
     );
     assert_eq!(
@@ -521,7 +523,7 @@ fn integration() {
     assert_eq!(graph.update_vertex_weight(VertexIndex(1), bjǫrg), Ok(()));
     assert_eq!(
         graph.get_vertex_weight(VertexIndex(1)),
-        Ok(bjǫrg),
+        Ok(&bjǫrg),
         "should return Bjǫrg instead of Bjǫrn"
     );
     assert_eq!(graph.count_vertices(), 5, "should still have 5 vertices");
@@ -529,14 +531,15 @@ fn integration() {
     // Update a hyperedge's weight.
     // First case: the index is the last one, no internal index alteration
     // occurs.
+    let fifth_hyperedge = Hyperedge::new("sleep", 0);
     assert_eq!(
-        graph.update_hyperedge_weight(HyperedgeIndex(4), Hyperedge::new("sleep", 0)),
+        graph.update_hyperedge_weight(HyperedgeIndex(4), fifth_hyperedge),
         Ok(()),
         "should update the weight of the fifth hyperedge"
     );
     assert_eq!(
         graph.get_hyperedge_weight(HyperedgeIndex(4)),
-        Ok(Hyperedge::new("sleep", 0)),
+        Ok(&fifth_hyperedge),
         "should get the new weight of the fifth hyperedge"
     );
     assert_eq!(
@@ -546,14 +549,15 @@ fn integration() {
     );
     // Second case: the index is not the last one, an internal index alteration
     // occurs but is anyway fixed by the insertion.
+    let first_hyperedge = Hyperedge::new("pass the purple ball", 3);
     assert_eq!(
-        graph.update_hyperedge_weight(HyperedgeIndex(0), Hyperedge::new("pass the purple ball", 3)),
+        graph.update_hyperedge_weight(HyperedgeIndex(0), first_hyperedge),
         Ok(()),
         "should update the weight of the first hyperedge"
     );
     assert_eq!(
         graph.get_hyperedge_weight(HyperedgeIndex(0)),
-        Ok(Hyperedge::new("pass the purple ball", 3)),
+        Ok(&first_hyperedge),
         "should get the new weight of the first hyperedge"
     );
     assert_eq!(
@@ -563,20 +567,17 @@ fn integration() {
     );
     // Check the eventual errors.
     assert_eq!(
-        graph.update_hyperedge_weight(HyperedgeIndex(0), Hyperedge::new("pass the purple ball", 3)),
+        graph.update_hyperedge_weight(HyperedgeIndex(0), first_hyperedge),
         Err(HypergraphError::HyperedgeWeightUnchanged {
             index: HyperedgeIndex(0),
-            weight: Hyperedge::new("pass the purple ball", 3)
+            weight: first_hyperedge,
         }),
         "should return an explicit error since this weight has not changed"
     );
     assert_eq!(
-        graph.update_hyperedge_weight(
-            HyperedgeIndex(0),
-            Hyperedge::new("meditate like a Jedi", 10)
-        ),
+        graph.update_hyperedge_weight(HyperedgeIndex(0), fourth_hyperedge),
         Err(HypergraphError::HyperedgeWeightAlreadyAssigned(
-            Hyperedge::new("meditate like a Jedi", 10)
+            fourth_hyperedge
         )),
         "should return an explicit error since this weight is already assigned"
     );


### PR DESCRIPTION
- Adds `into_iter()` for hypergraph
- Returns references for weights instead of owned values
- Adjusts documentation
- Updates and adds new integration tests