### PR TITLE
feat(hasher): user AHash instead of the default hasher from IndexMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +196,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +231,7 @@ dependencies = [
 name = "hypergraph"
 version = "2.0.0"
 dependencies = [
+ "ahash",
  "criterion",
  "indexmap",
  "itertools",
@@ -258,9 +282,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "log"
@@ -298,6 +322,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -500,6 +530,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +545,12 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.56"
 version = "2.0.0"
 
 [dependencies]
+ahash = "0.8.3"
 indexmap = { version = "1.9.2", features = ["rayon"] }
 itertools = "0.10.5"
 rayon = "1.7.0"

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use bi_hash_map::BiHashMap;
-use types::{AIndexMap, AIndexSet};
+use types::{AIndexMap, AIndexSet, ARandomState};
 
 // Reexport indexes at this level.
 pub use crate::core::indexes::{HyperedgeIndex, VertexIndex};
@@ -142,10 +142,10 @@ where
         Hypergraph {
             hyperedges_count: 0,
             hyperedges_mapping: BiHashMap::default(),
-            hyperedges: AIndexSet::with_capacity_and_hasher(hyperedges, Default::default()),
+            hyperedges: AIndexSet::with_capacity_and_hasher(hyperedges, ARandomState::default()),
             vertices_count: 0,
             vertices_mapping: BiHashMap::default(),
-            vertices: AIndexMap::with_capacity_and_hasher(vertices, Default::default()),
+            vertices: AIndexMap::with_capacity_and_hasher(vertices, ARandomState::default()),
         }
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,6 +7,8 @@ mod indexes;
 #[doc(hidden)]
 pub mod iterator;
 mod shared;
+#[doc(hidden)]
+mod types;
 mod utils;
 #[doc(hidden)]
 pub mod vertices;
@@ -18,7 +20,7 @@ use std::{
 };
 
 use bi_hash_map::BiHashMap;
-use indexmap::{IndexMap, IndexSet};
+use types::{AIndexMap, AIndexSet};
 
 // Reexport indexes at this level.
 pub use crate::core::indexes::{HyperedgeIndex, VertexIndex};
@@ -65,20 +67,24 @@ impl<HE> Deref for HyperedgeKey<HE> {
 pub struct Hypergraph<V, HE> {
     /// Vertices are stored as a map whose unique keys are the weights
     /// and the values are a set of the hyperedges indexes which include
-    // the current vertex.
-    vertices: IndexMap<V, IndexSet<usize>>,
+    /// the current vertex.
+    vertices: AIndexMap<V, AIndexSet<usize>>,
 
     /// Hyperedges are stored as a set whose unique keys are a combination of
     /// vertices indexes and a weight. Two or more hyperedges can contain
     /// the exact same vertices (non-simple hypergraph).
-    hyperedges: IndexSet<HyperedgeKey<HE>>,
+    hyperedges: AIndexSet<HyperedgeKey<HE>>,
 
-    // Bi-directional maps for hyperedges and vertices.
+    /// Bi-directional map for hyperedges.
     hyperedges_mapping: BiHashMap<HyperedgeIndex>,
+
+    /// Bi-directional map for vertices.
     vertices_mapping: BiHashMap<VertexIndex>,
 
-    // Stable index generation counters.
+    /// Stable index generation counter for hyperedges.
     hyperedges_count: usize,
+
+    /// Stable index generation counter for vertices.
     vertices_count: usize,
 }
 
@@ -136,10 +142,10 @@ where
         Hypergraph {
             hyperedges_count: 0,
             hyperedges_mapping: BiHashMap::default(),
-            hyperedges: IndexSet::with_capacity(hyperedges),
+            hyperedges: AIndexSet::with_capacity_and_hasher(hyperedges, Default::default()),
             vertices_count: 0,
             vertices_mapping: BiHashMap::default(),
-            vertices: IndexMap::with_capacity(vertices),
+            vertices: AIndexMap::with_capacity_and_hasher(vertices, Default::default()),
         }
     }
 }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -1,0 +1,8 @@
+use ahash::RandomState;
+use indexmap::{IndexMap, IndexSet};
+
+/// Type alias to use AHash as a faster hasher for `IndexMap`.
+pub(crate) type AIndexMap<K, V> = IndexMap<K, V, RandomState>;
+
+/// Type alias to use AHash as a faster hasher for `IndexSet`.
+pub(crate) type AIndexSet<T> = IndexSet<T, RandomState>;

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -1,8 +1,11 @@
 use ahash::RandomState;
 use indexmap::{IndexMap, IndexSet};
 
-/// Type alias to use AHash as a faster hasher for `IndexMap`.
+/// Type alias to use `AHash` as a faster hasher for `IndexMap`.
 pub(crate) type AIndexMap<K, V> = IndexMap<K, V, RandomState>;
 
-/// Type alias to use AHash as a faster hasher for `IndexSet`.
+/// Type alias to use `AHash` as a faster hasher for `IndexSet`.
 pub(crate) type AIndexSet<T> = IndexSet<T, RandomState>;
+
+/// Type alias for the `AHash` hasher factory.
+pub(crate) type ARandomState = RandomState;

--- a/src/core/vertices/add_vertex.rs
+++ b/src/core/vertices/add_vertex.rs
@@ -1,6 +1,7 @@
 use crate::{
-    core::types::AIndexSet, errors::HypergraphError, HyperedgeTrait, Hypergraph, VertexIndex,
-    VertexTrait,
+    core::types::{AIndexSet, ARandomState},
+    errors::HypergraphError,
+    HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait,
 };
 
 impl<V, HE> Hypergraph<V, HE>
@@ -18,7 +19,10 @@ where
 
         self.vertices
             .entry(weight)
-            .or_insert(AIndexSet::with_capacity_and_hasher(0, Default::default()));
+            .or_insert(AIndexSet::with_capacity_and_hasher(
+                0,
+                ARandomState::default(),
+            ));
 
         let internal_index = self
             .vertices

--- a/src/core/vertices/add_vertex.rs
+++ b/src/core/vertices/add_vertex.rs
@@ -1,6 +1,7 @@
-use indexmap::IndexSet;
-
-use crate::{errors::HypergraphError, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait};
+use crate::{
+    core::types::AIndexSet, errors::HypergraphError, HyperedgeTrait, Hypergraph, VertexIndex,
+    VertexTrait,
+};
 
 impl<V, HE> Hypergraph<V, HE>
 where
@@ -17,7 +18,7 @@ where
 
         self.vertices
             .entry(weight)
-            .or_insert(IndexSet::with_capacity(0));
+            .or_insert(AIndexSet::with_capacity_and_hasher(0, Default::default()));
 
         let internal_index = self
             .vertices


### PR DESCRIPTION
This PR replaces the default hasher used by `IndexMap` with `aHash` which is significantly faster and might help with performance (see #41):

https://github.com/tkaitchuck/aHash

```sh
❯ cargo bench
   Compiling libc v0.2.140
   Compiling version_check v0.9.4
   Compiling once_cell v1.17.1
   Compiling ahash v0.8.3
   Compiling num_cpus v1.13.1
   Compiling getrandom v0.2.8
   Compiling atty v0.2.14
   Compiling rayon-core v1.11.0
   Compiling rayon v1.7.0
   Compiling indexmap v1.9.2
   Compiling clap v3.2.20
   Compiling hypergraph v2.0.0 (/home/yamafaktory/dev/hypergraph)
   Compiling criterion v0.4.0
    Finished bench [optimized] target(s) in 15.08s
     Running unittests src/lib.rs (target/release/deps/hypergraph-5d513d277c88fba9)

running 2 tests
test core::utils::tests::check_matching ... ignored
test core::utils::tests::check_not_matching ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/performance.rs (target/release/deps/performance-a99c33b9a748f5af)
get-hyperedge-vertices  time:   [105.82 ns 107.64 ns 110.76 ns]
                        change: [-16.494% -14.273% -11.943%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

get-hyperedge-connecting
                        time:   [493.56 ns 497.42 ns 502.15 ns]
                        change: [-19.068% -16.308% -13.596%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe

Benchmarking get-all-hyperedges-intersections: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 10.0s, enable flat sampling, or reduce sample count to 40.
get-all-hyperedges-intersections
                        time:   [1.9768 ms 1.9874 ms 1.9994 ms]
                        change: [-19.507% -15.967% -12.410%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  2 (2.00%) high mild
  7 (7.00%) high severe

dijkstra                time:   [27.461 ns 27.885 ns 28.372 ns]
                        change: [-19.639% -17.739% -15.824%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  7 (7.00%) high mild
  10 (10.00%) high severe

dijkstra-reversed       time:   [14.904 ns 15.051 ns 15.223 ns]
                        change: [-19.714% -17.661% -15.785%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  3 (3.00%) low mild
  5 (5.00%) high mild
  4 (4.00%) high severe

remove-vertex           time:   [15.227 ns 15.350 ns 15.479 ns]
                        change: [-31.573% -29.274% -27.000%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

remove-hyperedge        time:   [15.146 ns 15.255 ns 15.384 ns]
                        change: [-26.221% -23.829% -21.468%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high mild
```