### PR TITLE
bump ahash crate to fix build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,14 +4,15 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -392,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oorandom"
@@ -563,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -589,7 +590,7 @@ checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -797,3 +798,23 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]

--- a/benches/performance.rs
+++ b/benches/performance.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::{Display, Formatter, Result};
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use hypergraph::{HyperedgeIndex, Hypergraph, VertexIndex};
 use itertools::Itertools;
 

--- a/src/core/errors.rs
+++ b/src/core/errors.rs
@@ -9,7 +9,7 @@ where
     V: Copy + Eq,
     HE: Copy + Eq,
 {
-    /// Error when a HyperedgeIndex was not found.
+    /// Error when a `HyperedgeIndex` was not found.
     #[error("HyperedgeIndex {0} was not found")]
     HyperedgeIndexNotFound(HyperedgeIndex),
 
@@ -66,7 +66,7 @@ where
     #[error("At least two hyperedges must be provided to be joined")]
     HyperedgesInvalidJoin,
 
-    /// Error when a VertexIndex was not found.
+    /// Error when a `VertexIndex` was not found.
     #[error("VertexIndex {0} was not found")]
     VertexIndexNotFound(VertexIndex),
 

--- a/src/core/hyperedges/add_hyperedge.rs
+++ b/src/core/hyperedges/add_hyperedge.rs
@@ -1,6 +1,6 @@
 use crate::{
-    errors::HypergraphError, HyperedgeIndex, HyperedgeKey, HyperedgeTrait, Hypergraph, VertexIndex,
-    VertexTrait,
+    HyperedgeIndex, HyperedgeKey, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait,
+    errors::HypergraphError,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/hyperedges/clear_hyperedges.rs
+++ b/src/core/hyperedges/clear_hyperedges.rs
@@ -1,7 +1,7 @@
 use rayon::prelude::*;
 
 use crate::{
-    bi_hash_map::BiHashMap, errors::HypergraphError, HyperedgeTrait, Hypergraph, VertexTrait,
+    HyperedgeTrait, Hypergraph, VertexTrait, bi_hash_map::BiHashMap, errors::HypergraphError,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/hyperedges/contract_hyperedge_vertices.rs
+++ b/src/core/hyperedges/contract_hyperedge_vertices.rs
@@ -2,8 +2,8 @@ use itertools::Itertools;
 use rayon::prelude::*;
 
 use crate::{
-    core::utils::are_slices_equal, errors::HypergraphError, HyperedgeIndex, HyperedgeTrait,
-    Hypergraph, VertexIndex, VertexTrait,
+    HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait,
+    core::utils::are_slices_equal, errors::HypergraphError,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/hyperedges/get_hyperedge.rs
+++ b/src/core/hyperedges/get_hyperedge.rs
@@ -1,4 +1,4 @@
-use crate::{errors::HypergraphError, HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexTrait};
+use crate::{HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexTrait, errors::HypergraphError};
 
 impl<V, HE> Hypergraph<V, HE>
 where

--- a/src/core/hyperedges/get_hyperedge_vertices.rs
+++ b/src/core/hyperedges/get_hyperedge_vertices.rs
@@ -1,6 +1,6 @@
 use crate::{
-    errors::HypergraphError, HyperedgeIndex, HyperedgeKey, HyperedgeTrait, Hypergraph, VertexIndex,
-    VertexTrait,
+    HyperedgeIndex, HyperedgeKey, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait,
+    errors::HypergraphError,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/hyperedges/get_hyperedge_weight.rs
+++ b/src/core/hyperedges/get_hyperedge_weight.rs
@@ -1,4 +1,4 @@
-use crate::{errors::HypergraphError, HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexTrait};
+use crate::{HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexTrait, errors::HypergraphError};
 
 impl<V, HE> Hypergraph<V, HE>
 where

--- a/src/core/hyperedges/get_hyperedges.rs
+++ b/src/core/hyperedges/get_hyperedges.rs
@@ -1,6 +1,6 @@
 use rayon::prelude::*;
 
-use crate::{errors::HypergraphError, HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexTrait};
+use crate::{HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexTrait, errors::HypergraphError};
 
 impl<V, HE> Hypergraph<V, HE>
 where

--- a/src/core/hyperedges/get_hyperedges_connecting.rs
+++ b/src/core/hyperedges/get_hyperedges_connecting.rs
@@ -1,8 +1,8 @@
 use rayon::prelude::*;
 
 use crate::{
-    core::shared::Connection, errors::HypergraphError, HyperedgeIndex, HyperedgeTrait, Hypergraph,
-    VertexIndex, VertexTrait,
+    HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, core::shared::Connection,
+    errors::HypergraphError,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/hyperedges/get_hyperedges_intersections.rs
+++ b/src/core/hyperedges/get_hyperedges_intersections.rs
@@ -2,8 +2,8 @@ use itertools::Itertools;
 use rayon::prelude::*;
 
 use crate::{
-    errors::HypergraphError, HyperedgeIndex, HyperedgeKey, HyperedgeTrait, Hypergraph, VertexIndex,
-    VertexTrait,
+    HyperedgeIndex, HyperedgeKey, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait,
+    errors::HypergraphError,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/hyperedges/get_hyperedges_intersections.rs
+++ b/src/core/hyperedges/get_hyperedges_intersections.rs
@@ -1,5 +1,4 @@
 use itertools::Itertools;
-use rayon::prelude::*;
 
 use crate::{
     HyperedgeIndex, HyperedgeKey, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait,

--- a/src/core/hyperedges/get_hyperedges_intersections.rs
+++ b/src/core/hyperedges/get_hyperedges_intersections.rs
@@ -26,7 +26,7 @@ where
 
         // Get the internal vertices of the hyperedges and keep the eventual error.
         let vertices = hyperedges
-            .into_par_iter()
+            .into_iter()
             .map(|hyperedge_index| {
                 self.get_internal_hyperedge(hyperedge_index)
                     .and_then(|internal_index| {

--- a/src/core/hyperedges/get_internal_hyperedge.rs
+++ b/src/core/hyperedges/get_internal_hyperedge.rs
@@ -1,4 +1,4 @@
-use crate::{errors::HypergraphError, HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexTrait};
+use crate::{HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexTrait, errors::HypergraphError};
 
 impl<V, HE> Hypergraph<V, HE>
 where

--- a/src/core/hyperedges/get_internal_hyperedges.rs
+++ b/src/core/hyperedges/get_internal_hyperedges.rs
@@ -1,4 +1,4 @@
-use crate::{errors::HypergraphError, HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexTrait};
+use crate::{HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexTrait, errors::HypergraphError};
 
 impl<V, HE> Hypergraph<V, HE>
 where

--- a/src/core/hyperedges/join_hyperedges.rs
+++ b/src/core/hyperedges/join_hyperedges.rs
@@ -1,7 +1,7 @@
 use rayon::prelude::*;
 
 use crate::{
-    errors::HypergraphError, HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait,
+    HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, errors::HypergraphError,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/hyperedges/remove_hyperedge.rs
+++ b/src/core/hyperedges/remove_hyperedge.rs
@@ -1,5 +1,5 @@
 use crate::{
-    errors::HypergraphError, HyperedgeIndex, HyperedgeKey, HyperedgeTrait, Hypergraph, VertexTrait,
+    HyperedgeIndex, HyperedgeKey, HyperedgeTrait, Hypergraph, VertexTrait, errors::HypergraphError,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/hyperedges/reverse_hyperedge.rs
+++ b/src/core/hyperedges/reverse_hyperedge.rs
@@ -1,6 +1,6 @@
 use rayon::prelude::*;
 
-use crate::{errors::HypergraphError, HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexTrait};
+use crate::{HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexTrait, errors::HypergraphError};
 
 impl<V, HE> Hypergraph<V, HE>
 where

--- a/src/core/hyperedges/update_hyperedge_vertices.rs
+++ b/src/core/hyperedges/update_hyperedge_vertices.rs
@@ -1,8 +1,8 @@
 use rayon::prelude::*;
 
 use crate::{
-    core::utils::are_slices_equal, errors::HypergraphError, HyperedgeIndex, HyperedgeKey,
-    HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait,
+    HyperedgeIndex, HyperedgeKey, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait,
+    core::utils::are_slices_equal, errors::HypergraphError,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/hyperedges/update_hyperedge_weight.rs
+++ b/src/core/hyperedges/update_hyperedge_weight.rs
@@ -1,5 +1,5 @@
 use crate::{
-    errors::HypergraphError, HyperedgeIndex, HyperedgeKey, HyperedgeTrait, Hypergraph, VertexTrait,
+    HyperedgeIndex, HyperedgeKey, HyperedgeTrait, Hypergraph, VertexTrait, errors::HypergraphError,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/iterator.rs
+++ b/src/core/iterator.rs
@@ -1,6 +1,6 @@
 use rayon::prelude::*;
 
-use crate::{errors::HypergraphError, HyperedgeKey, HyperedgeTrait, Hypergraph, VertexTrait};
+use crate::{HyperedgeKey, HyperedgeTrait, Hypergraph, VertexTrait, errors::HypergraphError};
 
 impl<V, HE> IntoIterator for Hypergraph<V, HE>
 where

--- a/src/core/shared.rs
+++ b/src/core/shared.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use rayon::prelude::*;
 
 use crate::{
-    errors::HypergraphError, HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait,
+    HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, errors::HypergraphError,
 };
 
 /// Enumeration of the different types of connection.

--- a/src/core/vertices/add_vertex.rs
+++ b/src/core/vertices/add_vertex.rs
@@ -1,7 +1,7 @@
 use crate::{
+    HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait,
     core::types::{AIndexSet, ARandomState},
     errors::HypergraphError,
-    HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/vertices/get_adjacent_vertices_from.rs
+++ b/src/core/vertices/get_adjacent_vertices_from.rs
@@ -1,8 +1,8 @@
 use rayon::prelude::*;
 
 use crate::{
-    core::shared::Connection, errors::HypergraphError, HyperedgeTrait, Hypergraph, VertexIndex,
-    VertexTrait,
+    HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, core::shared::Connection,
+    errors::HypergraphError,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/vertices/get_adjacent_vertices_to.rs
+++ b/src/core/vertices/get_adjacent_vertices_to.rs
@@ -1,8 +1,8 @@
 use rayon::prelude::*;
 
 use crate::{
-    core::shared::Connection, errors::HypergraphError, HyperedgeTrait, Hypergraph, VertexIndex,
-    VertexTrait,
+    HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, core::shared::Connection,
+    errors::HypergraphError,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/vertices/get_dijkstra_connections.rs
+++ b/src/core/vertices/get_dijkstra_connections.rs
@@ -7,7 +7,7 @@ use std::{
 use rayon::prelude::*;
 
 use crate::{
-    errors::HypergraphError, HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait,
+    HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, errors::HypergraphError,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/core/vertices/get_full_adjacent_vertices_from.rs
+++ b/src/core/vertices/get_full_adjacent_vertices_from.rs
@@ -1,9 +1,9 @@
 use indexmap::IndexMap;
-use itertools::{fold, Itertools};
+use itertools::{Itertools, fold};
 
 use crate::{
-    core::shared::Connection, errors::HypergraphError, HyperedgeIndex, HyperedgeTrait, Hypergraph,
-    VertexIndex, VertexTrait,
+    HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, core::shared::Connection,
+    errors::HypergraphError,
 };
 
 #[allow(clippy::type_complexity)]

--- a/src/core/vertices/get_full_adjacent_vertices_to.rs
+++ b/src/core/vertices/get_full_adjacent_vertices_to.rs
@@ -1,9 +1,9 @@
 use indexmap::IndexMap;
-use itertools::{fold, Itertools};
+use itertools::{Itertools, fold};
 
 use crate::{
-    core::shared::Connection, errors::HypergraphError, HyperedgeIndex, HyperedgeTrait, Hypergraph,
-    VertexIndex, VertexTrait,
+    HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, core::shared::Connection,
+    errors::HypergraphError,
 };
 
 #[allow(clippy::type_complexity)]

--- a/src/core/vertices/get_full_vertex_hyperedges.rs
+++ b/src/core/vertices/get_full_vertex_hyperedges.rs
@@ -1,6 +1,6 @@
 use rayon::prelude::*;
 
-use crate::{errors::HypergraphError, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait};
+use crate::{HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, errors::HypergraphError};
 
 impl<V, HE> Hypergraph<V, HE>
 where

--- a/src/core/vertices/get_internal_vertex.rs
+++ b/src/core/vertices/get_internal_vertex.rs
@@ -1,4 +1,4 @@
-use crate::{errors::HypergraphError, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait};
+use crate::{HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, errors::HypergraphError};
 
 impl<V, HE> Hypergraph<V, HE>
 where

--- a/src/core/vertices/get_internal_vertices.rs
+++ b/src/core/vertices/get_internal_vertices.rs
@@ -1,6 +1,6 @@
 use rayon::prelude::*;
 
-use crate::{errors::HypergraphError, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait};
+use crate::{HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, errors::HypergraphError};
 
 impl<V, HE> Hypergraph<V, HE>
 where

--- a/src/core/vertices/get_vertex.rs
+++ b/src/core/vertices/get_vertex.rs
@@ -1,4 +1,4 @@
-use crate::{errors::HypergraphError, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait};
+use crate::{HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, errors::HypergraphError};
 
 impl<V, HE> Hypergraph<V, HE>
 where

--- a/src/core/vertices/get_vertex_degree_in.rs
+++ b/src/core/vertices/get_vertex_degree_in.rs
@@ -1,6 +1,6 @@
 use crate::{
-    core::shared::Connection, errors::HypergraphError, HyperedgeTrait, Hypergraph, VertexIndex,
-    VertexTrait,
+    HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, core::shared::Connection,
+    errors::HypergraphError,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/vertices/get_vertex_degree_out.rs
+++ b/src/core/vertices/get_vertex_degree_out.rs
@@ -1,6 +1,6 @@
 use crate::{
-    core::shared::Connection, errors::HypergraphError, HyperedgeTrait, Hypergraph, VertexIndex,
-    VertexTrait,
+    HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, core::shared::Connection,
+    errors::HypergraphError,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/vertices/get_vertex_hyperedges.rs
+++ b/src/core/vertices/get_vertex_hyperedges.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 
 use crate::{
-    errors::HypergraphError, HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait,
+    HyperedgeIndex, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, errors::HypergraphError,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/vertices/get_vertex_weight.rs
+++ b/src/core/vertices/get_vertex_weight.rs
@@ -1,4 +1,4 @@
-use crate::{errors::HypergraphError, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait};
+use crate::{HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, errors::HypergraphError};
 
 impl<V, HE> Hypergraph<V, HE>
 where

--- a/src/core/vertices/get_vertices.rs
+++ b/src/core/vertices/get_vertices.rs
@@ -1,6 +1,6 @@
 use rayon::prelude::*;
 
-use crate::{errors::HypergraphError, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait};
+use crate::{HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, errors::HypergraphError};
 
 impl<V, HE> Hypergraph<V, HE>
 where

--- a/src/core/vertices/remove_vertex.rs
+++ b/src/core/vertices/remove_vertex.rs
@@ -1,7 +1,7 @@
 use rayon::prelude::*;
 
 use crate::{
-    errors::HypergraphError, HyperedgeKey, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait,
+    HyperedgeKey, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, errors::HypergraphError,
 };
 
 impl<V, HE> Hypergraph<V, HE>

--- a/src/core/vertices/update_vertex_weight.rs
+++ b/src/core/vertices/update_vertex_weight.rs
@@ -1,4 +1,4 @@
-use crate::{errors::HypergraphError, HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait};
+use crate::{HyperedgeTrait, Hypergraph, VertexIndex, VertexTrait, errors::HypergraphError};
 
 impl<V, HE> Hypergraph<V, HE>
 where

--- a/tests/integration_contraction.rs
+++ b/tests/integration_contraction.rs
@@ -4,7 +4,7 @@
 mod common;
 
 use common::{Hyperedge, Vertex};
-use hypergraph::{errors::HypergraphError, HyperedgeIndex, Hypergraph, VertexIndex};
+use hypergraph::{HyperedgeIndex, Hypergraph, VertexIndex, errors::HypergraphError};
 
 #[test]
 fn integration_contration() {

--- a/tests/integration_iterator.rs
+++ b/tests/integration_iterator.rs
@@ -44,14 +44,17 @@ fn integration_iterator() {
         vec![
             (hyperedge_one, vec![vertex_one, vertex_two, vertex_three]),
             (hyperedge_two, vec![vertex_four, vertex_five]),
-            (
-                hyperedge_three,
-                vec![vertex_three, vertex_three, vertex_three]
-            ),
-            (
-                hyperedge_four,
-                vec![vertex_five, vertex_four, vertex_three, vertex_one]
-            )
+            (hyperedge_three, vec![
+                vertex_three,
+                vertex_three,
+                vertex_three
+            ]),
+            (hyperedge_four, vec![
+                vertex_five,
+                vertex_four,
+                vertex_three,
+                vertex_one
+            ])
         ],
         "should provide `into_iter()` yelding a vector of tuples of the form (hyperedge, vector of vertices)"
     );

--- a/tests/integration_join.rs
+++ b/tests/integration_join.rs
@@ -4,7 +4,7 @@
 mod common;
 
 use common::{Hyperedge, Vertex};
-use hypergraph::{errors::HypergraphError, Hypergraph};
+use hypergraph::{Hypergraph, errors::HypergraphError};
 
 #[test]
 fn integration_contration() {

--- a/tests/integration_main.rs
+++ b/tests/integration_main.rs
@@ -4,7 +4,7 @@
 mod common;
 
 use common::{Hyperedge, Vertex};
-use hypergraph::{errors::HypergraphError, HyperedgeIndex, Hypergraph, VertexIndex};
+use hypergraph::{HyperedgeIndex, Hypergraph, VertexIndex, errors::HypergraphError};
 
 #[test]
 fn integration_main() {


### PR DESCRIPTION
currently, cargo build generates the following error due to the removal of stdsim: https://github.com/rust-lang/rust/pull/117372

```bash
error[E0635]: unknown feature stdsimd
--> /home/cmichaud/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ahash-0.8.3/src/lib.rs:99:42
|
99 | #![cfg_attr(feature = "stdsimd", feature(stdsimd))]
```

Also fixed two errors reported by clippy and ran `cargo fmt` that updated around 40 files.